### PR TITLE
Add: four unit tests

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1162,6 +1162,27 @@ mod verbose {
             Ok(())
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::Escape;
+        use std::fmt::Write;
+
+        #[test]
+        fn escape_tab() {
+            let mut s = String::new();
+            write!(&mut s, "{:?}", Escape(b"hello\tworld")).unwrap();
+            assert_eq!(s, "b\"hello\\tworld\"");
+        }
+
+        #[test]
+        fn escape_backslash() {
+            let mut s = String::new();
+            write!(&mut s, "{:?}", Escape(b"hello\\world")).unwrap();
+            println!("{}", s);
+            assert_eq!(s, "b\"hello\\\\world\"");
+        }
+    }
 }
 
 #[cfg(feature = "__tls")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -389,4 +389,12 @@ mod tests {
         let nested = super::request(io);
         assert!(nested.is_timeout());
     }
+
+    /// Ensured that the error Kind Upgrade contains its expected error string
+    #[test]
+    fn test_fmt_upgrade_error_msg() {
+        let err = Error::new(Kind::Upgrade, None::<Error>);
+
+        assert!(err.to_string().contains("error upgrading connection"));
+    }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -76,6 +76,14 @@ async fn user_agent() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
 }
 
+// Tests that build returns error when user_agent is invalid.
+// Increases branch coverage in async_impl/client.rs build by 1 branch.
+#[tokio::test]
+async fn user_agent_invalid() {
+    let res = reqwest::Client::builder().user_agent("\n").build();
+    assert!(res.is_err());
+}
+
 #[tokio::test]
 async fn response_text() {
     let _ = env_logger::try_init();


### PR DESCRIPTION
Added four unit tests to connect.rs, error.rs and tests/client.rs. They increase the coverage of:
* build function in async_impl/client.rs
* fmt function implementation for "fmt::Display for Error" in error.rs
* fmt function implementation for "fmt::debug for Escape" in connect.rs

Closes #17
Closes #18
Closes #23 
Closes #24